### PR TITLE
to fix behavior to work with `pull-double-newline`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ pull(
 `options` is an object with the following optional keys:
 
 - `open`: string to be prepended to first output string
-- `close`: string to be appended to last output string
+- `prefix`: string to be prepended to every non-first output string
+- `suffix`: string to be appended to every output string
+- `close`: string to be appended after stream is complete
 - `indent`: passed as third argument to `JSON.stringify`
-- `separator`: string to be (ap|pre)pended to every other output string
-- `prepend`: if `true` prepend separator, otherwise append separator
 - `stringify`: custom function to use instead of `JSON.stringify`
 
 `stringify(options)` returns a through [`pull-stream`](https://pull-stream.github.io).
@@ -38,30 +38,28 @@ defaults options are for [double newline delimited json](https://github.com/domi
 ```js
 {
   open: '',
-  separator: '\n\n',
+  prefix: '',
+  suffix: '\n\n',
   close: '',
   indent: 2,
-  prepend: false,
   stringify: JSON.stringify
 }
 ```
 
-### `stringify.ldjson(stringifier)`
+### `stringify.ldjson(stringify)`
 
-### `stringify.lines(stringifier)`
+### `stringify.lines(stringify)`
 
 for single newline delimited json use `stringify.ldjson()` or `stringify.lines()`:
 
 ```js
 {
-  open: '',
-  separator: '\n',
-  close: '',
+  suffix: '\n',
   indent: 0
 }
 ```
 
-you can pass a custom stringifier as an argument.
+you can pass a custom stringify as an argument.
 
 ```js
 // compatible with JSON but supports buffers.
@@ -75,7 +73,7 @@ stringify.lines(JSONB.stringify)
 ```
 
 
-### `stringify.array()`
+### `stringify.array(stringify)`
 
 for a single json array use `stringify.array()`
 
@@ -84,8 +82,7 @@ for a single json array use `stringify.array()`
   open: '[',
   separator: ',\n',
   close: ']\n',
-  indent: 2,
-  prepend: true
+  indent: 2
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 JSON.stringify as pull stream
 
+## example
+
 ``` js
 var pull = require('pull-stream')
 var stringify = require('pull-stringify')
@@ -14,31 +16,79 @@ pull(
 )
 ```
 
-`pull-stringify` takes the same arguments as
-[JSONStream.stringify](https://github.com/dominictarr/JSONStream#jsonstreamstringifyopen-sep-close) but as a pull stream.
+## usage
 
-Also if you want line separated json, a default is provided:
+### `stringify = require('pull-stringify')`
 
-``` js
-pull(
-  pull.value([A, B, C]),
-  stringify.lines(),
-  toPull(process.stdout)
-)
+### `stringify(options)`
+
+`options` is an object with the following optional keys:
+
+- `open`: string to be prepended to first output string
+- `close`: string to be appended to last output string
+- `indent`: passed as third argument to `JSON.stringify`
+- `separator`: string to be (ap|pre)pended to every other output string
+- `prepend`: if `true` prepend separator, otherwise append separator
+- `stringify`: custom function to use instead of `JSON.stringify`
+
+`stringify(options)` returns a through [`pull-stream`](https://pull-stream.github.io).
+
+defaults options are for [double newline delimited json](https://github.com/dominictarr/pull-json-doubleline/blob/master/index.js). double newline delimiting means you can use indented json as the stream format, which is more human readable.
+
+```js
+{
+  open: '',
+  separator: '\n\n',
+  close: '',
+  indent: 2,
+  prepend: false,
+  stringify: JSON.stringify
+}
 ```
 
-to use a non-custom stringifyer use the final argument.
+### `stringify.ldjson(stringifier)`
 
-``` js
-//compatible with JSON but supports buffers.
+### `stringify.lines(stringifier)`
+
+for single newline delimited json use `stringify.ldjson()` or `stringify.lines()`:
+
+```js
+{
+  open: '',
+  separator: '\n',
+  close: '',
+  indent: 0
+}
+```
+
+you can pass a custom stringifier as an argument.
+
+```js
+// compatible with JSON but supports buffers.
 var JSONB = require('json-buffer')
 
-//use defaults for op, cl, and sep
-stringify(null, null, null, JSONB.stringify)
+// use defaults
+stringify({ stringify: JSONB.stringify })
 
-//or
+// or
 stringify.lines(JSONB.stringify)
 ```
+
+
+### `stringify.array()`
+
+for a single json array use `stringify.array()`
+
+```js
+{
+  open: '[',
+  separator: ',\n',
+  close: ']\n',
+  indent: 2,
+  prepend: true
+}
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -13,13 +13,12 @@ function pullStringify (options) {
   var indent = defined(options.indent, 2)
   var stringify = defined(options.stringify, JSON.stringify)
 
-  var first = true
-  var ended
+  var first = true, ended
   return function (read) {
     return function (end, cb) {
-      if (ended) return cb(ended)
+      if(ended) return cb(ended)
       read(null, function (end, data) {
-        if (!end) {
+        if(!end) {
           var f = first
           first = false
 
@@ -27,7 +26,7 @@ function pullStringify (options) {
           cb(null, (f ? open : prefix) + string + suffix)
         } else {
           ended = end
-          if (ended !== true) return cb(ended)
+          if(ended !== true) return cb(ended)
           cb(null, first ? open + close : close)
         }
       })

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ function pullStringify (options) {
 
   // default is pretty double newline delimited json
   var open = defined(options.open, '')
-  var separator = defined(options.separator, '\n\n')
+  var prefix = defined(options.prefix, '')
+  var suffix = defined(options.suffix, '\n\n')
   var close = defined(options.close, '')
   var indent = defined(options.indent, 2)
-  var prepend = defined(options.prepend, false)
   var stringify = defined(options.stringify, JSON.stringify)
 
   var first = true
@@ -20,13 +20,11 @@ function pullStringify (options) {
       if (ended) return cb(ended)
       read(null, function (end, data) {
         if (!end) {
-          var prefix = first ? open
-            : prepend ? separator : ''
-          var suffix = prepend ? '' : separator
-          var string = stringify(data, null, indent)
+          var f = first
           first = false
 
-          cb(null, prefix + string + suffix)
+          var string = stringify(data, null, indent)
+          cb(null, (f ? open : prefix) + string + suffix)
         } else {
           ended = end
           if (ended !== true) return cb(ended)
@@ -40,20 +38,19 @@ function pullStringify (options) {
 module.exports.lines =
 module.exports.ldjson = function (stringify) {
   return pullStringify({
-    open: '',
-    close: '',
-    separator: '\n',
+    suffix: '\n',
     indent: 0,
     stringify: stringify
   })
 }
 
-module.exports.array = function () {
+module.exports.array = function (stringify) {
   return pullStringify({
     open: '[',
+    prefix: ',\n',
+    suffix: '',
     close: ']\n',
-    separator: ',\n',
     indent: 2,
-    prepend: true
+    stringify: stringify
   })
 }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     "pull-pushable": "^2.0.0",
     "pull-split": "^0.2.0",
     "pull-stream": "^3.4.2",
-    "standard": "^7.1.2",
     "tape": "^4.5.1"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "tape test.js"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,18 @@
     "type": "git",
     "url": "git://github.com/dominictarr/pull-stringify.git"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "defined": "^1.0.0"
+  },
+  "devDependencies": {
+    "pull-pushable": "^2.0.0",
+    "pull-split": "^0.2.0",
+    "pull-stream": "^3.4.2",
+    "standard": "^7.1.2",
+    "tape": "^4.5.1"
+  },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "standard && tape test.js"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "license": "MIT"

--- a/test.js
+++ b/test.js
@@ -1,0 +1,91 @@
+const test = require('tape')
+const pull = require('pull-stream')
+const Pushable = require('pull-pushable')
+const stringify = require('./')
+const split = require('pull-split')
+
+const values = [
+  { name: 'air' },
+  { name: 'box' },
+  { name: 'cat' }
+]
+
+test('stringify as default', function (t) {
+  const expected = `{
+  "name": "air"
+}
+
+{
+  "name": "box"
+}
+
+{
+  "name": "cat"
+}
+
+`
+
+  testValues(t, stringify(), expected)
+})
+
+test('stringify as array', function (t) {
+  const expected = `[{
+  "name": "air"
+},
+{
+  "name": "box"
+},
+{
+  "name": "cat"
+}]
+`
+
+  testValues(t, stringify.array(), expected)
+})
+
+test('stringify as ldjson', function (t) {
+  const expected = `{"name":"air"}
+{"name":"box"}
+{"name":"cat"}
+`
+
+  testValues(t, stringify.ldjson(), expected)
+})
+
+test('stringify delimits after value', function (t) {
+  const pushable = Pushable()
+
+  var i = 0
+  pull(
+    pushable,
+    stringify(),
+    split('\n\n', function (value) {
+      return value ? JSON.parse(value) : null
+    }),
+    pull.drain(function (actual) {
+      const expected = values[i++]
+      t.deepEqual(actual, expected)
+
+      if (i === values.length) {
+        pushable.end()
+        t.end()
+      }
+    })
+  )
+
+  Object.keys(values).forEach(function (index) {
+    pushable.push(values[index])
+  })
+})
+
+function testValues (t, through, expected) {
+  pull(
+    pull.values(values.slice()),
+    through,
+    pull.concat(function (err, actual) {
+      if (err) { return t.end(err) }
+      t.equal(actual, expected)
+      t.end()
+    })
+  )
+}


### PR DESCRIPTION
BREAKING CHANGE
- now accepts options as an object instead of n-ary arguments
- default options are for double-newline delimited json
- previous default is available at stringify.array()
- standard code style
- add tape tests

request for review: @dominictarr :)
